### PR TITLE
Remove a (possibly?) unneeded import

### DIFF
--- a/Python/paragraph_scraper/paragraph_scraper.py
+++ b/Python/paragraph_scraper/paragraph_scraper.py
@@ -3,7 +3,6 @@
 
 import re
 import requests
-import sys
 
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
Since you already import sys in __main__, and it doesn't seem to be used elsewhere, I think you can remove it. Haven't tested but seems OK.